### PR TITLE
Add in VPC Security Groups to allow inbound SSH and RDP

### DIFF
--- a/Complete_VPC_Setup/VPC_Two-Tier_IGW_NAT-GW.cat.rb
+++ b/Complete_VPC_Setup/VPC_Two-Tier_IGW_NAT-GW.cat.rb
@@ -237,7 +237,7 @@ resource 'cluster_sg_rule_int_udp', type: 'security_group_rule' do
   } end
 end
 
-resource "sec_group_rule_ssh", type: "security_group_rule" do
+resource 'sec_group_rule_ssh', type: 'security_group_rule' do
   name join(["SshRule-",last(split(@@deployment.href,"/"))])
   description "Allow SSH access."
   source_type "cidr_ips"
@@ -251,7 +251,7 @@ resource "sec_group_rule_ssh", type: "security_group_rule" do
   } end
 end
 
-resource "sec_group_rule_rdp", type: "security_group_rule" do
+resource 'sec_group_rule_rdp', type: 'security_group_rule' do
   name join(["SshRule-",last(split(@@deployment.href,"/"))])
   description "Allow RDP access."
   source_type "cidr_ips"

--- a/Complete_VPC_Setup/VPC_Two-Tier_IGW_NAT-GW.cat.rb
+++ b/Complete_VPC_Setup/VPC_Two-Tier_IGW_NAT-GW.cat.rb
@@ -343,7 +343,7 @@ operation "start" do
 end
 
 # Create the network and related components and NAT gateway and servers and this and that.
-define launch(@pub_server, @priv_servers, @vpc_network, @vpc_subnet, @vpc_priv_subnet, @vpc_igw, @vpc_nat_gw, @vpc_nat_ip, @vpc_route_table, @vpc_route, @vpc_priv_route_table, @cluster_sg, @cluster_sg_rule_int_tcp, @cluster_sg_rule_int_udp, @ssh_key, $param_location, $map_cloud, $map_config, $map_image_name_root) return @pub_server, @priv_servers, @vpc_network, @vpc_subnet, @vpc_priv_subnet, @vpc_igw, @vpc_nat_gw, @vpc_nat_ip, @vpc_route_table, @vpc_route, @vpc_priv_route_table, @cluster_sg, @cluster_sg_rule_int_tcp, @cluster_sg_rule_int_udp, @ssh_key do
+define launch(@pub_server, @priv_servers, @vpc_network, @vpc_subnet, @vpc_priv_subnet, @vpc_igw, @vpc_nat_gw, @vpc_nat_ip, @vpc_route_table, @vpc_route, @vpc_priv_route_table, @cluster_sg, @cluster_sg_rule_int_tcp,@sec_group_rule_ssh,@sec_group_rule_rdp, @cluster_sg_rule_int_udp, @ssh_key, $param_location, $map_cloud, $map_config, $map_image_name_root) return @pub_server, @priv_servers, @vpc_network, @vpc_subnet, @vpc_priv_subnet, @vpc_igw, @vpc_nat_gw, @vpc_nat_ip, @vpc_route_table, @vpc_route, @vpc_priv_route_table, @cluster_sg, @cluster_sg_rule_int_tcp,@sec_group_rule_ssh, @sec_group_rule_rdp @cluster_sg_rule_int_udp, @ssh_key do
 
   # provision networking
   provision(@vpc_network)
@@ -373,7 +373,8 @@ define launch(@pub_server, @priv_servers, @vpc_network, @vpc_subnet, @vpc_priv_s
     
   provision(@cluster_sg_rule_int_tcp)
   provision(@cluster_sg_rule_int_udp)
-  
+  provision(@sec_group_rule_ssh)
+  provision(@sec_group_rule_rdp)
   provision(@ssh_key)
 
   concurrent return @pub_server, @priv_servers do

--- a/Complete_VPC_Setup/VPC_Two-Tier_IGW_NAT-GW.cat.rb
+++ b/Complete_VPC_Setup/VPC_Two-Tier_IGW_NAT-GW.cat.rb
@@ -343,7 +343,7 @@ operation "start" do
 end
 
 # Create the network and related components and NAT gateway and servers and this and that.
-define launch(@pub_server, @priv_servers, @vpc_network, @vpc_subnet, @vpc_priv_subnet, @vpc_igw, @vpc_nat_gw, @vpc_nat_ip, @vpc_route_table, @vpc_route, @vpc_priv_route_table, @cluster_sg, @cluster_sg_rule_int_tcp,@sec_group_rule_ssh,@sec_group_rule_rdp, @cluster_sg_rule_int_udp, @ssh_key, $param_location, $map_cloud, $map_config, $map_image_name_root) return @pub_server, @priv_servers, @vpc_network, @vpc_subnet, @vpc_priv_subnet, @vpc_igw, @vpc_nat_gw, @vpc_nat_ip, @vpc_route_table, @vpc_route, @vpc_priv_route_table, @cluster_sg, @cluster_sg_rule_int_tcp,@sec_group_rule_ssh, @sec_group_rule_rdp @cluster_sg_rule_int_udp, @ssh_key do
+define launch(@pub_server, @priv_servers, @vpc_network, @vpc_subnet, @vpc_priv_subnet, @vpc_igw, @vpc_nat_gw, @vpc_nat_ip, @vpc_route_table, @vpc_route, @vpc_priv_route_table, @cluster_sg, @cluster_sg_rule_int_tcp,@sec_group_rule_ssh,@sec_group_rule_rdp, @cluster_sg_rule_int_udp, @ssh_key, $param_location, $map_cloud, $map_config, $map_image_name_root) return @pub_server, @priv_servers, @vpc_network, @vpc_subnet, @vpc_priv_subnet, @vpc_igw, @vpc_nat_gw, @vpc_nat_ip, @vpc_route_table, @vpc_route, @vpc_priv_route_table, @cluster_sg, @cluster_sg_rule_int_tcp,@sec_group_rule_ssh, @sec_group_rule_rdp, @cluster_sg_rule_int_udp, @ssh_key do
 
   # provision networking
   provision(@vpc_network)

--- a/Complete_VPC_Setup/VPC_Two-Tier_IGW_NAT-GW.cat.rb
+++ b/Complete_VPC_Setup/VPC_Two-Tier_IGW_NAT-GW.cat.rb
@@ -237,6 +237,35 @@ resource 'cluster_sg_rule_int_udp', type: 'security_group_rule' do
   } end
 end
 
+resource "sec_group_rule_ssh", type: "security_group_rule" do
+  name join(["SshRule-",last(split(@@deployment.href,"/"))])
+  description "Allow SSH access."
+  source_type "cidr_ips"
+  security_group @cluster_sg
+  protocol "tcp"
+  direction "ingress"
+  cidr_ips "0.0.0.0/0"
+  protocol_details do {
+    "start_port" => "22",
+    "end_port" => "22"
+  } end
+end
+
+resource "sec_group_rule_rdp", type: "security_group_rule" do
+  name join(["SshRule-",last(split(@@deployment.href,"/"))])
+  description "Allow RDP access."
+  source_type "cidr_ips"
+  security_group @cluster_sg
+  protocol "tcp"
+  direction "ingress"
+  cidr_ips "0.0.0.0/0"
+  protocol_details do {
+    "start_port" => "3389",
+    "end_port" => "3389"
+  } end
+end
+
+
 ### SSH Key ###
 resource "ssh_key", type: "ssh_key" do
   like @common_resources.ssh_key


### PR DESCRIPTION
The current security group setup does not allow for any inbound traffic into the VPC from the internet. This will allow for inbound SSH and RDP access to the instances. End users will have a much easier experience in testing / evaluating the self service product.

